### PR TITLE
 Add support for parsing build result from string

### DIFF
--- a/src/main/java/hudson/model/ExternalRun.java
+++ b/src/main/java/hudson/model/ExternalRun.java
@@ -37,6 +37,7 @@ import java.io.PrintStream;
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.zip.GZIPInputStream;
+import java.util.Scanner;
 
 import static javax.xml.stream.XMLStreamConstants.*;
 
@@ -85,6 +86,18 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
         charset = c;
     }
 
+    private Result parseResult(String text) {
+        Result result;
+        Scanner sc = new Scanner(text);
+        if (sc.hasNextInt()) {
+            result = sc.nextInt()==0 ? Result.SUCCESS : Result.FAILURE;
+        }
+        else {
+            result = Result.fromString(text);
+        }
+        return result;
+    }
+
     /**
      * Instead of performing a build, accept the log and the return code
      * from a remote machine.
@@ -130,11 +143,9 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                     if(type== CHARACTERS || type== CDATA)
                         logger.print(p.getText());
                 }
+
                 p.nextTag(); // get to <result>
-
-
-
-                Result r = Integer.parseInt(elementText(p))==0?Result.SUCCESS:Result.FAILURE;
+                Result r = parseResult(elementText(p));
 
                 do {
                     p.nextTag();

--- a/src/test/java/hudson/model/ExternalRunTest.java
+++ b/src/test/java/hudson/model/ExternalRunTest.java
@@ -20,14 +20,29 @@ public class ExternalRunTest extends HudsonTestCase {
         b.acceptRemoteSubmission(new StringReader(
             "<run><log content-encoding='UTF-8'>AAAAAAAA</log><result>0</result><duration>100</duration></run>"
         ));
-        assertEquals(b.getResult(),Result.SUCCESS);
+        assertEquals(Result.SUCCESS,b.getResult());
         assertEquals(b.getDuration(),100);
 
         b = p.newBuild();
         b.acceptRemoteSubmission(new StringReader(
-            "<run><log content-encoding='UTF-8'>AAAAAAAA</log><result>1</result>"
+            "<run><log content-encoding='UTF-8'>AAAAAAAA</log><result>1</result></run>"
         ));
-        assertEquals(b.getResult(),Result.FAILURE);
+        assertEquals(Result.FAILURE,b.getResult());
+    }
+
+    public void testStringResult() throws Exception {
+        ExternalJob p = jenkins.createProject(ExternalJob.class, createUniqueProjectName());
+        ExternalRun b = p.newBuild();
+        b.acceptRemoteSubmission(new StringReader(
+            "<run><log/><result>SUCCESS</result></run>"
+        ));
+        assertEquals(Result.SUCCESS,b.getResult());
+
+        b = p.newBuild();
+        b.acceptRemoteSubmission(new StringReader(
+            "<run><log/><result>ABORTED</result></run>"
+        ));
+        assertEquals(Result.ABORTED,b.getResult());
     }
 
     @Bug(11592)


### PR DESCRIPTION
Previously only numeric process return values were supported in
XML result-tag. This change adds support for parsing string
results. Biggest advantage is that this allows setting any build
result supported by hudson.model.Result and not only success or
failure. For backward compatibility parsing a numeric return value
is always attempted first.
