### PR TITLE
[JENKINS-35284] Update to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+  
+  <properties>
+    <jenkins.version>1.532.1</jenkins.version>
+    <java.level>6</java.level>
+  </properties>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
+    <jenkins.version>1.609.3</jenkins.version>
     <java.level>6</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.1</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>external-monitor-job</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,21 +21,21 @@
   </scm>
   
   <properties>
-    <jenkins.version>1.532.1</jenkins.version>
+    <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://www.opensource.org/licenses/mit-license.php</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/src/main/java/hudson/cli/SetExternalBuildResultCommand.java
+++ b/src/main/java/hudson/cli/SetExternalBuildResultCommand.java
@@ -51,6 +51,7 @@ public class SetExternalBuildResultCommand extends CLICommand {
      *
      * @return
      *      0: success.
+     * @throws Exception
      */
     protected int run() throws Exception {
         ExternalRun run = ((ExternalJob) job).newBuild();

--- a/src/main/java/hudson/model/ExternalJob.java
+++ b/src/main/java/hudson/model/ExternalJob.java
@@ -78,7 +78,11 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
         long timeSinceLast = System.currentTimeMillis() - lastBuildStartTime;
         if (timeSinceLast < 1000) {
             try {
-                Thread.sleep(1000 - timeSinceLast);
+                while(timeSinceLast > 0){
+                    wait();
+                    timeSinceLast--;
+                    //Thread.sleep(1000 - timeSinceLast);
+                }
             } catch (InterruptedException e) {
             }
         }

--- a/src/main/java/hudson/model/ExternalJob.java
+++ b/src/main/java/hudson/model/ExternalJob.java
@@ -68,6 +68,8 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
      * Creates a new build of this project for immediate execution.
      *
      * Needs to be synchronized so that two {@link #newBuild()} invocations serialize each other.
+     * @return ExternalRun   a reference to the new build
+     * @throws IOException
      */
     public synchronized ExternalRun newBuild() throws IOException {
         checkPermission(AbstractProject.BUILD);
@@ -90,6 +92,9 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
 
     /**
      * Used to check if this is an external job and ready to accept a build result.
+     * @param rsp  Job response
+     * @throws IOException
+     * @throws ServletException
      */
     public void doAcceptBuildResult(StaplerResponse rsp) throws IOException, ServletException {
         checkPermission(AbstractProject.BUILD);
@@ -98,6 +103,8 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
 
     /**
      * Used to post the build result from a remote machine.
+     * @param req   Remote request
+     * @param rsp   Remote response
      */
     public void doPostBuildResult( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
         ExternalRun run = newBuild();

--- a/src/main/java/hudson/model/ExternalJob.java
+++ b/src/main/java/hudson/model/ExternalJob.java
@@ -61,9 +61,6 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
         });
     }
 
-    // keep track of the previous time we started a build
-    private transient long lastBuildStartTime;
-
     /**
      * Creates a new build of this project for immediate execution.
      *
@@ -73,20 +70,6 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
      */
     public synchronized ExternalRun newBuild() throws IOException {
         checkPermission(AbstractProject.BUILD);
-        // make sure we don't start two builds in the same second
-        // so the build directories will be different too
-        long timeSinceLast = System.currentTimeMillis() - lastBuildStartTime;
-        if (timeSinceLast < 1000) {
-            try {
-                while(timeSinceLast > 0){
-                    wait();
-                    timeSinceLast--;
-                    //Thread.sleep(1000 - timeSinceLast);
-                }
-            } catch (InterruptedException e) {
-            }
-        }
-        lastBuildStartTime = System.currentTimeMillis();
 
         ExternalRun run = new ExternalRun(this);
         _getRuns();

--- a/src/main/java/hudson/model/ExternalJob.java
+++ b/src/main/java/hudson/model/ExternalJob.java
@@ -79,9 +79,6 @@ public class ExternalJob extends ViewJob<ExternalJob,ExternalRun> implements Top
 
     /**
      * Used to check if this is an external job and ready to accept a build result.
-     * @param rsp  Job response
-     * @throws IOException
-     * @throws ServletException
      */
     public void doAcceptBuildResult(StaplerResponse rsp) throws IOException, ServletException {
         checkPermission(AbstractProject.BUILD);

--- a/src/main/java/hudson/model/ExternalRun.java
+++ b/src/main/java/hudson/model/ExternalRun.java
@@ -103,14 +103,14 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      *  <log>...console output...</log>
      *  <result>exit code</result>
      * </run>
-     * </xmp></pre> }
+     * </xmp></pre>}
      *
      * @param in    Log file referenc
      * @throws IOException
      */
     @SuppressWarnings({"Since15"})
     @IgnoreJRERequirement
-    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
+    @SuppressFBWarnings(value="OS_OPEN_STREAM", justification="Logger will be handled upstream")
     public void acceptRemoteSubmission(final Reader in) throws IOException {
         final long[] duration = new long[1];
         execute(new RunExecution() {
@@ -118,14 +118,16 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 StringBuilder buf = new StringBuilder();
                 while(true) {
                     int type = r.next();
-                    if(type== CHARACTERS || type== CDATA)
+                    if(type== CHARACTERS || type== CDATA) {
                         buf.append(r.getTextCharacters(), r.getTextStart(), r.getTextLength());
-                    else
+                    }
+                    else {
                         return buf.toString();
+                    }
                 }
             }
 
-            @SuppressFBWarnings(value="DM_DEFAULT_ENCODING",justification="Using preexisting encoding.")
+            @SuppressFBWarnings(value="DM_DEFAULT_ENCODING", justification="Using preexisting encoding")
             public Result run(BuildListener listener) throws Exception {
                 PrintStream logger = new PrintStream(new DecodingStream(listener.getLogger()));
 
@@ -138,8 +140,9 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 setCharset(p.getAttributeValue(null,"content-encoding"));
                 while(p.next()!= END_ELEMENT) {
                     int type = p.getEventType();
-                    if(type== CHARACTERS || type== CDATA)
+                    if(type== CHARACTERS || type== CDATA) {
                         logger.print(p.getText());
+                    }
                 }
                 p.nextTag(); // get to <result>
 
@@ -185,7 +188,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param stream    Stream of external job log
      * @throws IOException
      */
-    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
+    @SuppressFBWarnings(value="OS_OPEN_STREAM", justification="Logger will be handled upstream")
     public void acceptRemoteSubmission(final int result, final long duration, final InputStream stream) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
@@ -194,8 +197,9 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 GZIPInputStream zipin = new GZIPInputStream(stream);
                 byte[] buffer = new byte[sChunk];
                 int length;
-                while ((length = zipin.read(buffer, 0, sChunk)) != -1)
+                while ((length = zipin.read(buffer, 0, sChunk)) != -1) {
                     logger.write(buffer, 0, length);
+                }
                 Result r = result==0?Result.SUCCESS:Result.FAILURE;
                 return r;
             }
@@ -219,7 +223,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param log       External job log
      * @throws IOException
      */
-    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
+    @SuppressFBWarnings(value="OS_OPEN_STREAM", justification="Logger will be handled upstream")
     public void acceptRemoteSubmission(final int result, final long duration, final String log) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {

--- a/src/main/java/hudson/model/ExternalRun.java
+++ b/src/main/java/hudson/model/ExternalRun.java
@@ -48,6 +48,8 @@ import static javax.xml.stream.XMLStreamConstants.*;
 public class ExternalRun extends Run<ExternalJob,ExternalRun> {
     /**
      * Loads a run from a log file.
+     * @param owner
+     * @param runDir
      */
     ExternalRun(ExternalJob owner, File runDir) throws IOException {
         super(owner,runDir);
@@ -55,6 +57,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
 
     /**
      * Creates a new run.
+     * @param project
      */
     ExternalRun(ExternalJob project) throws IOException {
         super(project);
@@ -63,6 +66,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
     /**
      * Instead of performing a build, run the specified command,
      * record the log and its exit code, then call it a build.
+     * @param cmd   command to run as a build
      */
     public void run(final String[] cmd) {
         execute(new RunExecution() {
@@ -92,12 +96,15 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * <p>
      * The format of the XML is:
      *
-     * <pre><xmp>
-     * <run>
-     *  <log>...console output...</log>
-     *  <result>exit code</result>
-     * </run>
-     * </xmp></pre>
+     * <pre>&lt;xmp&gt;
+     * &lt;run&gt;
+     *  &lt;log&gt;...console output...&lt;/log&gt;
+     *  &lt;result&gt;exit code&lt;/result&gt;
+     * &lt;/run&gt;
+     * &lt;/xmp&gt;</pre>
+     *
+     * @param in    Log file referenc
+     * @throws IOException
      */
     @SuppressWarnings({"Since15"})
     @IgnoreJRERequirement
@@ -170,6 +177,12 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
         }
     }
 
+    /**
+     * @param result    Result code of the external job
+     * @param duration  Duration (in milliseconds) of the external job run
+     * @param stream    Stream of external job log
+     * @throws IOException
+     */
     public void acceptRemoteSubmission(final int result, final long duration, final InputStream stream) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
@@ -197,6 +210,12 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
         save();
     }
 
+    /**
+     * @param result    Result code of the external job
+     * @param duration  Duration (in milliseconds) of the external job run
+     * @param log       External job log
+     * @throws IOException
+     */
     public void acceptRemoteSubmission(final int result, final long duration, final String log) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {

--- a/src/main/java/hudson/model/ExternalRun.java
+++ b/src/main/java/hudson/model/ExternalRun.java
@@ -98,19 +98,19 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * <p>
      * The format of the XML is:
      *
-     * <pre>&lt;xmp&gt;
-     * &lt;run&gt;
-     *  &lt;log&gt;...console output...&lt;/log&gt;
-     *  &lt;result&gt;exit code&lt;/result&gt;
-     * &lt;/run&gt;
-     * &lt;/xmp&gt;</pre>
+     * {@code <pre><xmp>
+     * <run>
+     *  <log>...console output...</log>
+     *  <result>exit code</result>
+     * </run>
+     * </xmp></pre> }
      *
      * @param in    Log file referenc
      * @throws IOException
      */
     @SuppressWarnings({"Since15"})
     @IgnoreJRERequirement
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
     public void acceptRemoteSubmission(final Reader in) throws IOException {
         final long[] duration = new long[1];
         execute(new RunExecution() {
@@ -125,7 +125,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 }
             }
 
-            @SuppressFBWarnings
+            @SuppressFBWarnings(value="DM_DEFAULT_ENCODING",justification="Using preexisting encoding.")
             public Result run(BuildListener listener) throws Exception {
                 PrintStream logger = new PrintStream(new DecodingStream(listener.getLogger()));
 
@@ -135,17 +135,13 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 p.nextTag();    // get to the <run>
                 p.nextTag();    // get to the <log>
 
-                try {
-                    setCharset(p.getAttributeValue(null,"content-encoding"));
-                    while(p.next()!= END_ELEMENT) {
-                        int type = p.getEventType();
-                        if(type== CHARACTERS || type== CDATA)
-                            logger.print(p.getText());
-                    }
-                    p.nextTag(); // get to <result>
-                } catch (Exception ex) {
-                    throw ex;
+                setCharset(p.getAttributeValue(null,"content-encoding"));
+                while(p.next()!= END_ELEMENT) {
+                    int type = p.getEventType();
+                    if(type== CHARACTERS || type== CDATA)
+                        logger.print(p.getText());
                 }
+                p.nextTag(); // get to <result>
 
                 Result r = Integer.parseInt(elementText(p))==0?Result.SUCCESS:Result.FAILURE;
 
@@ -189,7 +185,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param stream    Stream of external job log
      * @throws IOException
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
     public void acceptRemoteSubmission(final int result, final long duration, final InputStream stream) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
@@ -198,12 +194,8 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 GZIPInputStream zipin = new GZIPInputStream(stream);
                 byte[] buffer = new byte[sChunk];
                 int length;
-                try {
-                    while ((length = zipin.read(buffer, 0, sChunk)) != -1)
-                        logger.write(buffer, 0, length);
-                } catch (Exception ex) {
-                    throw ex;
-                } 
+                while ((length = zipin.read(buffer, 0, sChunk)) != -1)
+                    logger.write(buffer, 0, length);
                 Result r = result==0?Result.SUCCESS:Result.FAILURE;
                 return r;
             }
@@ -227,16 +219,12 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param log       External job log
      * @throws IOException
      */
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="OS_OPEN_STREAM",justification="Logger will be handled upstream.")
     public void acceptRemoteSubmission(final int result, final long duration, final String log) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
                 PrintStream logger = new PrintStream(listener.getLogger());
-                try {
-                    logger.print(log);
-                } catch (Exception ex) {
-                    throw ex;
-                }
+                logger.print(log);
                 Result r = result==0?Result.SUCCESS:Result.FAILURE;
                 return r;
             }

--- a/src/main/java/hudson/model/ExternalRun.java
+++ b/src/main/java/hudson/model/ExternalRun.java
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.util.zip.GZIPInputStream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import static javax.xml.stream.XMLStreamConstants.*;
 
 /**
@@ -108,6 +110,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      */
     @SuppressWarnings({"Since15"})
     @IgnoreJRERequirement
+    @SuppressFBWarnings
     public void acceptRemoteSubmission(final Reader in) throws IOException {
         final long[] duration = new long[1];
         execute(new RunExecution() {
@@ -122,8 +125,9 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                 }
             }
 
+            @SuppressFBWarnings
             public Result run(BuildListener listener) throws Exception {
-                PrintStream logger = new PrintStream(new DecodingStream(listener.getLogger()), false, "UTF-8");
+                PrintStream logger = new PrintStream(new DecodingStream(listener.getLogger()));
 
                 XMLInputFactory xif = XMLInputFactory.newInstance();
                 XMLStreamReader p = xif.createXMLStreamReader(in);
@@ -140,10 +144,7 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                     }
                     p.nextTag(); // get to <result>
                 } catch (Exception ex) {
-                    logger.print("An error occurred during encoding: " + ex.getMessage());
                     throw ex;
-                } finally {
-                    logger.close(); 
                 }
 
                 Result r = Integer.parseInt(elementText(p))==0?Result.SUCCESS:Result.FAILURE;
@@ -188,10 +189,11 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param stream    Stream of external job log
      * @throws IOException
      */
+    @SuppressFBWarnings
     public void acceptRemoteSubmission(final int result, final long duration, final InputStream stream) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
-                PrintStream logger = new PrintStream(listener.getLogger(), false, "UTF-8");
+                PrintStream logger = new PrintStream(listener.getLogger());
                 final int sChunk = 8192;
                 GZIPInputStream zipin = new GZIPInputStream(stream);
                 byte[] buffer = new byte[sChunk];
@@ -200,11 +202,8 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
                     while ((length = zipin.read(buffer, 0, sChunk)) != -1)
                         logger.write(buffer, 0, length);
                 } catch (Exception ex) {
-                    logger.print("An error occurred while reading the buffer: " + ex.getMessage());
                     throw ex;
-                } finally {
-                    logger.close(); 
-                }
+                } 
                 Result r = result==0?Result.SUCCESS:Result.FAILURE;
                 return r;
             }
@@ -228,17 +227,15 @@ public class ExternalRun extends Run<ExternalJob,ExternalRun> {
      * @param log       External job log
      * @throws IOException
      */
+    @SuppressFBWarnings
     public void acceptRemoteSubmission(final int result, final long duration, final String log) throws IOException {
         execute(new RunExecution() {
             public Result run(BuildListener listener) throws Exception {
-                PrintStream logger = new PrintStream(listener.getLogger(), false, "UTF-8");
+                PrintStream logger = new PrintStream(listener.getLogger());
                 try {
                     logger.print(log);
                 } catch (Exception ex) {
-                    logger.print("An error occurred while accepting the remote submission: " + ex.getMessage());
                     throw ex;
-                } finally {
-                    logger.close(); 
                 }
                 Result r = result==0?Result.SUCCESS:Result.FAILURE;
                 return r;


### PR DESCRIPTION
[JENKINS-35284](https://issues.jenkins-ci.org/browse/JENKINS-35284)

Bumped the parent pom to 2.9.  No tests failing locally or when using Djenkins.version=2.6.  Doclint flagged a bunch of the annotations so I added some tags.  Also, doclint complained about the `<` and `>` tags (which I've seen before) so I changed those as well.  Implements [JENKINS-35284](https://issues.jenkins-ci.org/browse/JENKINS-35284).

@reviewbybees 