### PR TITLE
Remove only admin allowed to perform delete or configure operation.

### DIFF
--- a/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
+++ b/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
@@ -26,16 +26,16 @@ THE SOFTWARE.
   Side panel for the build view.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 	<l:header title="${it.name}">
 	  <st:include page="rssHeader.jelly" />
 	</l:header>
+	<j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
 	<l:side-panel>
 	  <l:tasks>
 	    <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
 	    <l:task icon="images/24x24/search.png" href="." title="${%Status}" />
-	    <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete Job}" permission="${it.DELETE}" />
-	    <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" permission="${it.CONFIGURE}"/>
+		<p:configurable/>
 	    <st:include page="actions.jelly" />
 	  </l:tasks>
     

--- a/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
+++ b/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
 	  <l:tasks>
 	    <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
 	    <l:task icon="images/24x24/search.png" href="." title="${%Status}" />
-		<p:configurable/>
+        <p:configurable/>
 	    <st:include page="actions.jelly" />
 	  </l:tasks>
     

--- a/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
+++ b/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
@@ -34,10 +34,8 @@ THE SOFTWARE.
 	  <l:tasks>
 	    <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
 	    <l:task icon="images/24x24/search.png" href="." title="${%Status}" />
-	    <l:isAdmin>
-	      <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete Job}" />
-	      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" />
-	    </l:isAdmin>
+	    <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete Job}" permission="${it.DELETE}" />
+	    <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" permission="${it.CONFIGURE}"/>
 	    <st:include page="actions.jelly" />
 	  </l:tasks>
     


### PR DESCRIPTION
The `<l:isAdmin>` prevents Jenkins from displaying this UI, however it does not prevent a delete operation (I can still go to `/doDelete` or `/delete` in the URL and perform the delete operation).

@reviewbybees
