### PR TITLE
bump parent pom from 4.33 to 4.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.33</version>
+    <version>4.47</version>
     <relativePath/>
   </parent>
 
@@ -11,7 +11,6 @@
   <version>${changelist}</version>
   <packaging>hpi</packaging>
   <name>External Monitor Job Type Plugin</name>
-  <description>Adds the ability to monitor the result of externally executed jobs</description>
 
   <url>https://github.com/jenkinsci/external-monitor-job-plugin</url>
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Adds the ability to monitor the result of externally executed jobs
+</div>


### PR DESCRIPTION
4.47 got the fixed jenkins-test-harness to remove flakiness in Security2762Test
