### PR TITLE
Remove hierarchal navigation from side panel + change 'Status' icon to match Jenkins

### DIFF
--- a/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
+++ b/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
@@ -33,8 +33,7 @@ THE SOFTWARE.
 	<j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
 	<l:side-panel>
 	  <l:tasks>
-	    <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}" />
-	    <l:task icon="icon-search icon-md" href="." title="${%Status}" />
+	    <l:task icon="symbol-details" href="." title="${%Status}" />
         <p:configurable/>
 	    <st:include page="actions.jelly" />
 	  </l:tasks>

--- a/src/main/resources/hudson/model/ExternalRun/sidepanel.jelly
+++ b/src/main/resources/hudson/model/ExternalRun/sidepanel.jelly
@@ -30,7 +30,6 @@ THE SOFTWARE.
   <l:header title="${it.fullDisplayName}" />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="icon-up icon-md" href="${rootURL}/${it.parent.url}" title="${%Back to Job}" contextMenu="false"/>
       <l:task icon="icon-terminal icon-md" href="." title="${%Console Output}" />
       <j:if test="${(!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it,attrs.permission)) and it.hasArtifacts}">
         <l:task icon="icon-package icon-md" href="artifacts-index" title="${%Artifacts}" />


### PR DESCRIPTION
Small tweak to the side panel to remove the 'Back to Dashboard/Job' links as they're no longer used in Jenkins, as well as update the 'Status' icon from a search icon to a details icon.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
